### PR TITLE
Auto-derive INVITE_BASE_URL from Vercel deployment context

### DIFF
--- a/apps/server/src/connect.ts
+++ b/apps/server/src/connect.ts
@@ -30,6 +30,13 @@ function getBaseUrl(req: Request): string {
   return `${proto}://${host}`
 }
 
+function getInviteBaseUrl(): string {
+  return (
+    process.env.INVITE_BASE_URL ??
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000')
+  )
+}
+
 function timeAgo(dateStr: string | null): string {
   if (!dateStr) return 'never'
   const diff = Date.now() - new Date(dateStr).getTime()
@@ -167,7 +174,7 @@ export async function handleDashboard(req: Request, res: Response): Promise<void
 
   const inviteRows = invites.length
     ? invites.map(i => {
-        const url = `${baseUrl}/invite?code=${i.code}`
+        const url = `${getInviteBaseUrl()}/invite?code=${i.code}`
         return `
       <tr class="border-t-2 border-black">
         <td class="p-3 border-r-2 border-black font-mono text-xs text-gray-500">${i.code.slice(0, 8)}…</td>

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -123,6 +123,15 @@ app.post('/token', async (req, res) => {
   }
 })
 
+// Warn if invite base URL cannot be derived from environment
+if (!process.env.INVITE_BASE_URL && !process.env.VERCEL_URL) {
+  console.warn(
+    'Warning: INVITE_BASE_URL and VERCEL_URL are not set. ' +
+    'Invite links will fall back to http://localhost:3000. ' +
+    'Set INVITE_BASE_URL (or deploy on Vercel) for correct invite URLs in production.'
+  )
+}
+
 // Export for Vercel serverless
 export default app
 

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -36,6 +36,13 @@ function getBaseUrl(req: Request): string {
   return `${proto}://${host}`
 }
 
+function getInviteBaseUrl(): string {
+  return (
+    process.env.INVITE_BASE_URL ??
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000')
+  )
+}
+
 async function resolveAuth(req: Request): Promise<AuthContext | null> {
   const authHeader = req.headers.authorization
   if (!authHeader?.startsWith('Bearer ')) return null
@@ -229,10 +236,10 @@ async function callTool(
         })),
         pending_invites: pendingInvites.map((i) => ({
           code: i.code,
-          invite_url: `${baseUrl}/invite?code=${i.code}`,
+          invite_url: `${getInviteBaseUrl()}/invite?code=${i.code}`,
           created_at: i.created_at,
         })),
-        new_invite_url: `${baseUrl}/invite?code=${newInvite.code}`,
+        new_invite_url: `${getInviteBaseUrl()}/invite?code=${newInvite.code}`,
       }
       return { content: [{ type: 'text', text: JSON.stringify(info, null, 2) }] }
     }


### PR DESCRIPTION
Falls back to `VERCEL_URL` (automatically set by Vercel on all deployments) when `INVITE_BASE_URL` is not explicitly configured, and to `http://localhost:3000` for local dev.

- Adds `getInviteBaseUrl()` in `connect.ts` and `mcp.ts` implementing the fallback chain
- Replaces request-derived `baseUrl` with `getInviteBaseUrl()` for all invite link generation
- Adds a startup warning log when neither `INVITE_BASE_URL` nor `VERCEL_URL` is set

Closes #24