### PR TITLE
Validate required env vars at startup

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,4 +1,6 @@
 import 'dotenv/config'
+import { validateEnv } from './validateEnv'
+validateEnv()
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import express from 'express'

--- a/apps/server/src/validateEnv.ts
+++ b/apps/server/src/validateEnv.ts
@@ -1,0 +1,55 @@
+/**
+ * Validates that all required environment variables are set at server startup.
+ * Logs a clear, actionable error and exits with code 1 if any are missing.
+ */
+
+interface EnvVar {
+  name: string
+  description: string
+}
+
+// Always required
+const REQUIRED: EnvVar[] = [
+  { name: 'GITHUB_APP_ID', description: 'GitHub App ID (found in GitHub App settings)' },
+  { name: 'GITHUB_APP_CLIENT_ID', description: 'GitHub App OAuth client ID' },
+  { name: 'GITHUB_APP_CLIENT_SECRET', description: 'GitHub App OAuth client secret' },
+  { name: 'POSTGRES_URL', description: 'Neon Postgres connection string' },
+  { name: 'INVITE_BASE_URL', description: 'Public base URL of this server (e.g. https://your-app.vercel.app) — used to generate invite links' },
+]
+
+// Required unless GITHUB_PRIVATE_KEY_PATH is set
+const PRIVATE_KEY_VARS = ['GITHUB_PRIVATE_KEY', 'GITHUB_PRIVATE_KEY_PATH']
+
+export function validateEnv(): void {
+  const missing: string[] = []
+
+  for (const { name, description } of REQUIRED) {
+    if (!process.env[name]) {
+      missing.push(`  ${name}\n    → ${description}`)
+    }
+  }
+
+  // At least one of GITHUB_PRIVATE_KEY / GITHUB_PRIVATE_KEY_PATH must be set
+  const hasPrivateKey = PRIVATE_KEY_VARS.some((v) => process.env[v])
+  if (!hasPrivateKey) {
+    missing.push(
+      `  GITHUB_PRIVATE_KEY  (or GITHUB_PRIVATE_KEY_PATH)\n    → GitHub App private key (.pem contents, or path to file)`
+    )
+  }
+
+  if (missing.length === 0) return
+
+  console.error('\n' + '='.repeat(72))
+  console.error('ERROR: Missing required environment variables\n')
+  console.error('The following variables must be set before the server can start:\n')
+  for (const entry of missing) {
+    console.error(entry)
+  }
+  console.error('\nWhere to set them:')
+  console.error('  Vercel: Dashboard → Your Project → Settings → Environment Variables')
+  console.error('  Local:  Add to apps/server/.env (never commit this file)')
+  console.error('\nSee the README for full setup instructions.')
+  console.error('='.repeat(72) + '\n')
+
+  process.exit(1)
+}


### PR DESCRIPTION
Closes #27

On server startup, `validateEnv()` is called before any routes are registered. It checks:

- `GITHUB_APP_ID`
- `GITHUB_APP_CLIENT_ID`
- `GITHUB_APP_CLIENT_SECRET`
- `POSTGRES_URL`
- `INVITE_BASE_URL`
- `GITHUB_PRIVATE_KEY` or `GITHUB_PRIVATE_KEY_PATH` (at least one)

If any are missing, the server logs which vars are absent, points to Vercel Dashboard → Environment Variables (and local `.env` for local dev), then exits with code 1. No more silent startup with broken invite URL generation.