### PR TITLE
Warn and fallback when VERCEL_URL is absent in local dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,8 @@ PORT=3000
 # GITHUB_APP_SLUG=issue-collab-vyshnavsdeepak
 # GITHUB_APP_CLIENT_ID=Iv1.xxxxxxxxxxxxxxxx
 # GITHUB_APP_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+#
+# Optional: override the base URL used in invite links.
+# Auto-derived from VERCEL_URL on Vercel deployments; falls back to http://localhost:PORT locally.
+# Set this when auto-derivation produces the wrong URL (e.g. custom domains, tunnels).
+# COLLAB_URL=https://your-custom-domain.com

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -37,10 +37,17 @@ function getBaseUrl(req: Request): string {
 }
 
 function getInviteBaseUrl(): string {
-  return (
-    process.env.INVITE_BASE_URL ??
-    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000')
+  if (process.env.INVITE_BASE_URL) return process.env.INVITE_BASE_URL
+  if (process.env.COLLAB_URL) return process.env.COLLAB_URL
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`
+
+  const port = process.env.PORT ?? '3000'
+  const fallback = `http://localhost:${port}`
+  console.warn(
+    `[warn] VERCEL_URL is not set — invite URLs will use ${fallback}. ` +
+      `Set INVITE_BASE_URL or COLLAB_URL to override.`
   )
+  return fallback
 }
 
 async function resolveAuth(req: Request): Promise<AuthContext | null> {


### PR DESCRIPTION
Closes #59

`VERCEL_URL` is only injected by Vercel at build time, so local dev silently produced broken invite URLs. Changes:

- `getInviteBaseUrl()` now emits a `console.warn` when falling back to localhost so developers know which base URL is being used
- Fallback respects `PORT` env var (`http://localhost:$PORT`) instead of hardcoding `:3000`
- `COLLAB_URL` is now supported as an explicit override (alongside `INVITE_BASE_URL`)
- `.env.example` documents `COLLAB_URL` under the VERCEL SERVER section