### PR TITLE
Auto-create demo invite code when invites table is empty at startup

### DIFF
--- a/apps/server/src/db.ts
+++ b/apps/server/src/db.ts
@@ -178,3 +178,15 @@ export async function listPendingInvitesForUser(userId: string): Promise<InviteC
   `
   return rows as InviteCode[]
 }
+
+export async function countInviteCodes(): Promise<number> {
+  const db = sql()
+  const rows = await db`SELECT COUNT(*)::int AS n FROM invite_codes`
+  return (rows[0] as { n: number }).n
+}
+
+export async function getFirstUser(): Promise<User | null> {
+  const db = sql()
+  const rows = await db`SELECT * FROM users ORDER BY created_at ASC LIMIT 1`
+  return (rows[0] as User) ?? null
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -6,7 +6,7 @@ import { join } from 'path'
 import express from 'express'
 import { z } from 'zod'
 import { getInstallationToken } from './github'
-import { getUserByApiKey } from './db'
+import { getUserByApiKey, runMigrations, countInviteCodes, getFirstUser, createInviteCode } from './db'
 import { handleConnect, handleConnectCallback, handleDashboard, handleDashboardLogin, handleDashboardCallback, handleDashboardLogout, handleCreateInvite, handleRevokeSession } from './connect'
 import { handleMcp, handleInvite, handleInviteCallback } from './mcp'
 
@@ -125,6 +125,28 @@ app.post('/token', async (req, res) => {
   }
 })
 
+async function seedDemoInviteIfNeeded(): Promise<void> {
+  if (!process.env.POSTGRES_URL) return
+  try {
+    await runMigrations()
+    const count = await countInviteCodes()
+    if (count > 0) return
+    const user = await getFirstUser()
+    if (!user) {
+      console.log('[demo] Invites table is empty but no users found — complete the /connect flow first.')
+      return
+    }
+    const invite = await createInviteCode(user.id)
+    const baseUrl =
+      process.env.INVITE_BASE_URL ??
+      (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : `http://localhost:${process.env.PORT ?? 3000}`)
+    console.log(`[demo] Invites table was empty — created demo invite for ${user.github_user ?? user.id}:`)
+    console.log(`[demo]   ${baseUrl}/invite?code=${invite.code}`)
+  } catch (err) {
+    console.warn(`[demo] Could not seed demo invite: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
 // Warn if invite base URL cannot be derived from environment
 if (!process.env.INVITE_BASE_URL && !process.env.VERCEL_URL) {
   console.warn(
@@ -149,5 +171,9 @@ if (!process.env.VERCEL) {
     console.log(`  POST /invite/callback`)
     console.log(`  POST /mcp   (hosted MCP)`)
     console.log(`  POST /token (installation token broker)`)
+    void seedDemoInviteIfNeeded()
   })
+} else {
+  // On Vercel cold start, attempt seeding in the background
+  void seedDemoInviteIfNeeded()
 }


### PR DESCRIPTION
If the `invite_codes` table has zero rows at server startup, insert one invite code (using the first user's ID) and log the full invite URL to stdout. Runs on local `app.listen` callback and on Vercel cold start. If no users exist yet, logs a prompt to complete the `/connect` flow first.

Closes #70