### PR TITLE
Add PR template with artifact verification checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Description
+
+<!-- Briefly describe what this PR does and why -->
+
+Closes #
+
+## Artifact Verification Checklist
+
+Before submitting this PR, confirm each item by replacing `[ ]` with `[x]`:
+
+- [ ] **Files/routes/components exist on this branch** – I ran `ls` (or equivalent) to confirm the specific files, directories, routes, or UI components claimed in this PR description actually exist in the branch (not just planned or described).
+- [ ] **Issue is fully resolved** – The issue being closed is completely addressed, not just partially. I have read the issue spec and verified every requirement is met.
+- [ ] **Artifact is reachable** – I ran a one-line test confirming the artifact works (e.g., `curl` the endpoint, opened the route in a browser, or ran the script and saw expected output). Paste the result or command used here:
+
+  ```
+  # paste test command and output here
+  ```
+
+> These checks exist because PRs previously closed issues without shipping the claimed code, creating false ground truth and wasting development effort.


### PR DESCRIPTION
Closes #72

Adds `.github/pull_request_template.md` with a mandatory checklist requiring PR authors to verify:
- Files/routes/components claimed in the PR actually exist on the branch
- The issue being closed is fully resolved (not partially)
- A one-line test confirming the artifact is reachable

Addresses the pattern of PRs closing issues without shipping code.