### PR TITLE
Improve POSTGRES_URL error message and add apps/server/.env.example

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -1,0 +1,36 @@
+# ─── apps/server environment variables ───────────────────────────────────────
+# Copy to apps/server/.env.local and fill in the values.
+# Alternatively, pull from Vercel: vercel env pull apps/server/.env.local
+
+# PostgreSQL connection string (Neon)
+# Get from: Neon dashboard → your project → Connection string
+# Or run:   vercel env pull apps/server/.env.local
+POSTGRES_URL=postgres://user:password@host/dbname?sslmode=require
+
+# GitHub App credentials
+# Get from: GitHub → Settings → Developer settings → GitHub Apps → Your App
+GITHUB_APP_ID=12345
+GITHUB_APP_INSTALLATION_ID=112169201
+GITHUB_APP_SLUG=your-app-slug
+
+# Option A: Path to downloaded .pem file (recommended for local dev)
+GITHUB_APP_PRIVATE_KEY_PATH=./private-key.pem
+
+# Option B: Paste the private key directly
+# GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
+# MIIEowIBAAKCAQEA...
+# -----END RSA PRIVATE KEY-----"
+
+# GitHub OAuth App credentials (for designer auth flow)
+# Found in: GitHub App settings → OAuth section
+GITHUB_APP_CLIENT_ID=Iv1.xxxxxxxxxxxxxxxx
+GITHUB_APP_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Developer auth secret — set to any random string
+DEV_SECRET=change-me-to-something-random
+
+# Optional: base URL for invite links (auto-derived from VERCEL_URL if unset)
+# INVITE_BASE_URL=https://your-deployment.vercel.app
+
+# Optional: server port for local dev (default: 3000)
+# PORT=3000

--- a/apps/server/src/create-test-invite.ts
+++ b/apps/server/src/create-test-invite.ts
@@ -63,6 +63,24 @@ async function main() {
 }
 
 main().catch(err => {
-  console.error('Failed:', err instanceof Error ? err.message : String(err))
+  const msg = err instanceof Error ? err.message : String(err)
+  if (msg.includes('POSTGRES_URL is not set')) {
+    console.error(`
+Error: POSTGRES_URL is not set.
+
+To fix this, add it to apps/server/.env.local:
+
+  POSTGRES_URL=postgres://...
+
+Where to get the value:
+  • Neon dashboard → your project → Connection string
+  • Or run: vercel env pull apps/server/.env.local
+    (requires Vercel project access)
+
+See apps/server/.env.example for all required variables.
+`)
+  } else {
+    console.error('Failed:', msg)
+  }
   process.exit(1)
 })


### PR DESCRIPTION
Closes #78

## Changes

- `apps/server/src/create-test-invite.ts`: detect missing `POSTGRES_URL` specifically and print where to get it (Neon dashboard or `vercel env pull apps/server/.env.local`) along with the exact env var to set
- `apps/server/.env.example`: new file documenting all server-specific env vars (`POSTGRES_URL`, `GITHUB_APP_ID`, etc.), separate from the root `.env.example` which covers the self-hosted path