### PR TITLE
Mark auto-seeded invite codes as demo

### DIFF
--- a/apps/server/src/__tests__/invite-flow.test.ts
+++ b/apps/server/src/__tests__/invite-flow.test.ts
@@ -39,9 +39,9 @@ vi.mock('../db.js', () => ({
 
   getInviteCode: (code: string) => Promise.resolve(inviteCodes.get(code) ?? null),
 
-  createInviteCode: (userId: string) => {
+  createInviteCode: (userId: string, isDemo = false) => {
     const code = newId()
-    const invite = { code, user_id: userId, used: false, created_at: new Date().toISOString() }
+    const invite = { code, user_id: userId, used: false, is_demo: isDemo, created_at: new Date().toISOString() }
     inviteCodes.set(code, invite)
     return Promise.resolve(invite)
   },
@@ -70,6 +70,8 @@ vi.mock('../db.js', () => ({
   listSessionsForUser: () => Promise.resolve([]),
   listPendingInvitesForUser: () => Promise.resolve([]),
   runMigrations: () => Promise.resolve(),
+  countInviteCodes: () => Promise.resolve(inviteCodes.size),
+  getFirstUser: () => Promise.resolve([...users.values()][0] ?? null),
   createUser: (params: { installationId: string; githubUser: string; repo?: string }) => {
     const user = {
       id: newId(),
@@ -161,13 +163,15 @@ describe('Designer invite flow', () => {
     expect(res.text).toContain('testdev/testrepo')
   })
 
-  it('step 3 — POST /invite/callback creates a designer session in the DB', async () => {
+  it('step 3 — POST /invite/callback creates a designer session and redirects to /designer', async () => {
     const res = await supertest(app)
       .post('/invite/callback')
       .type('form')
       .send({ code: inviteCode, name: 'alice' })
 
-    expect(res.status).toBe(200)
+    // Callback now redirects to /designer after creating the session
+    expect(res.status).toBe(302)
+    expect(res.headers['location']).toBe('/designer')
 
     // The invite should now be marked used
     const invite = inviteCodes.get(inviteCode)
@@ -180,9 +184,9 @@ describe('Designer invite flow', () => {
     expect(typeof session!['token']).toBe('string')
   })
 
-  it('step 4 — POST /invite/callback response contains valid MCP config JSON', async () => {
+  it('step 4 — POST /invite/callback sets a designer_session cookie', async () => {
     // Use a fresh invite code for this assertion
-    const freshInvite = { code: newId(), user_id: testUserId, used: false, created_at: new Date().toISOString() }
+    const freshInvite = { code: newId(), user_id: testUserId, used: false, is_demo: false, created_at: new Date().toISOString() }
     inviteCodes.set(freshInvite.code, freshInvite)
 
     const res = await supertest(app)
@@ -190,36 +194,11 @@ describe('Designer invite flow', () => {
       .type('form')
       .send({ code: freshInvite.code, name: 'bob' })
 
-    expect(res.status).toBe(200)
-    expect(res.headers['content-type']).toMatch(/html/)
+    expect(res.status).toBe(302)
 
-    // Extract the JSON from the <pre id="mcp-config"> element
-    const match = res.text.match(/<pre[^>]*id="mcp-config"[^>]*>([\s\S]*?)<\/pre>/)
-    expect(match).not.toBeNull()
-
-    // The HTML template HTML-escapes < and > in the config; unescape before parsing
-    const rawJson = match![1]
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&amp;/g, '&')
-      .replace(/&quot;/g, '"')
-      .trim()
-
-    let mcpConfig: unknown
-    expect(() => {
-      mcpConfig = JSON.parse(rawJson)
-    }).not.toThrow()
-
-    const cfg = mcpConfig as Record<string, unknown>
-    expect(cfg).toHaveProperty('mcpServers')
-
-    const servers = cfg['mcpServers'] as Record<string, unknown>
-    const server = servers['github-collab'] as Record<string, unknown>
-    expect(server).toBeDefined()
-    expect(typeof server['url']).toBe('string')
-    expect((server['url'] as string)).toContain('/mcp')
-
-    const headers = server['headers'] as Record<string, string>
-    expect(headers['Authorization']).toMatch(/^Bearer .+/)
+    // A Set-Cookie header with designer_session must be present
+    const setCookie = res.headers['set-cookie'] as string[] | string | undefined
+    const cookieStr = Array.isArray(setCookie) ? setCookie.join('; ') : (setCookie ?? '')
+    expect(cookieStr).toMatch(/designer_session=/)
   })
 })

--- a/apps/server/src/connect.ts
+++ b/apps/server/src/connect.ts
@@ -204,15 +204,18 @@ export async function handleDashboard(req: Request, res: Response): Promise<void
   const inviteRows = invites.length
     ? invites.map(i => {
         const url = `${getInviteBaseUrl()}/invite?code=${i.code}`
+        const actionCell = i.is_demo
+          ? `<span class="text-xs font-bold border-2 border-gray-400 px-2 py-0.5 text-gray-400">Demo — do not share</span>`
+          : `<button onclick="copyEl('inv-${i.code}', this)" class="text-xs font-bold border-2 border-black px-2 py-0.5 hover:bg-black hover:text-white">Copy</button>`
         return `
-      <tr class="border-t-2 border-black">
+      <tr class="border-t-2 border-black${i.is_demo ? ' opacity-50' : ''}">
         <td class="p-3 border-r-2 border-black font-mono text-xs text-gray-500">${i.code.slice(0, 8)}…</td>
         <td class="p-3 border-r-2 border-black">
           <span id="inv-${i.code}" class="font-mono text-xs">${esc(url)}</span>
         </td>
         <td class="p-3 border-r-2 border-black text-xs text-gray-500">${timeAgo(i.created_at)}</td>
         <td class="p-3">
-          <button onclick="copyEl('inv-${i.code}', this)" class="text-xs font-bold border-2 border-black px-2 py-0.5 hover:bg-black hover:text-white">Copy</button>
+          ${actionCell}
         </td>
       </tr>`
       }).join('')

--- a/apps/server/src/db.ts
+++ b/apps/server/src/db.ts
@@ -37,6 +37,9 @@ export async function runMigrations(): Promise<void> {
       created_at TIMESTAMPTZ DEFAULT NOW()
     )
   `
+  await db`
+    ALTER TABLE invite_codes ADD COLUMN IF NOT EXISTS is_demo BOOLEAN NOT NULL DEFAULT FALSE
+  `
 }
 
 export interface User {
@@ -61,6 +64,7 @@ export interface InviteCode {
   code: string
   user_id: string
   used: boolean
+  is_demo: boolean
   created_at: string
 }
 
@@ -146,11 +150,11 @@ export async function listSessionsForUser(userId: string): Promise<DesignerSessi
   return rows as DesignerSession[]
 }
 
-export async function createInviteCode(userId: string): Promise<InviteCode> {
+export async function createInviteCode(userId: string, isDemo = false): Promise<InviteCode> {
   const db = sql()
   const code = randomUUID()
   const rows = await db`
-    INSERT INTO invite_codes (code, user_id) VALUES (${code}, ${userId}) RETURNING *
+    INSERT INTO invite_codes (code, user_id, is_demo) VALUES (${code}, ${userId}, ${isDemo}) RETURNING *
   `
   return rows[0] as InviteCode
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -153,7 +153,7 @@ async function seedDemoInviteIfNeeded(): Promise<void> {
       console.log('[demo] Invites table is empty but no users found — complete the /connect flow first.')
       return
     }
-    const invite = await createInviteCode(user.id)
+    const invite = await createInviteCode(user.id, true)
     const baseUrl =
       process.env.INVITE_BASE_URL ??
       (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : `http://localhost:${process.env.PORT ?? 3000}`)

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -245,7 +245,7 @@ async function callTool(
           created_at: s.created_at,
           last_seen: s.last_seen,
         })),
-        pending_invites: pendingInvites.map((i) => ({
+        pending_invites: pendingInvites.filter((i) => !i.is_demo).map((i) => ({
           code: i.code,
           invite_url: `${getInviteBaseUrl()}/invite?code=${i.code}`,
           created_at: i.created_at,


### PR DESCRIPTION
Closes #81

Auto-seeded startup invites are now flagged with `is_demo = true` so they can't be confused with real invites.

**Changes:**
- DB migration: `ALTER TABLE invite_codes ADD COLUMN IF NOT EXISTS is_demo BOOLEAN NOT NULL DEFAULT FALSE`
- `createInviteCode(userId, isDemo?)` — optional second param, defaults to `false`
- `seedDemoInviteIfNeeded()` passes `isDemo = true`
- Dashboard: demo rows render muted (`opacity-50`) with a "Demo — do not share" badge in place of the Copy button
- `get_collaboration_info` MCP tool filters out demo codes from `pending_invites`
- Test fixes: add missing `countInviteCodes`/`getFirstUser` mocks; update step 3/4 assertions to match current redirect-to-`/designer` behavior (pre-existing breakage from designer portal PR)