### PR TITLE
Replace decommissioned server URL with github-issue-collab-server.vercel.app

### DIFF
--- a/packages/server/src/github.ts
+++ b/packages/server/src/github.ts
@@ -50,7 +50,7 @@ export async function getInstallationToken(
 
   if (process.env.COLLAB_KEY && !privateKey) {
     // Power-user path: fetch installation token from hosted server using COLLAB_KEY
-    const collabUrl = process.env.COLLAB_URL ?? 'https://server-pink-six-81.vercel.app'
+    const collabUrl = process.env.COLLAB_URL ?? 'https://github-issue-collab-server.vercel.app'
     const res = await fetch(`${collabUrl}/token`, {
       method: 'POST',
       headers: {


### PR DESCRIPTION
Closes #102

Updates the COLLAB_URL fallback in `packages/server/src/github.ts` from the decommissioned `server-pink-six-81.vercel.app` to `github-issue-collab-server.vercel.app`. The `public/index.html` MCP snippet already had the correct URL.