### PR TITLE
Log GitHub App callback URL at server startup

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -181,6 +181,11 @@ if (!process.env.INVITE_BASE_URL && !process.env.VERCEL_URL) {
   )
 }
 
+const baseUrl =
+  process.env.INVITE_BASE_URL ??
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : `http://localhost:${process.env.PORT ?? 3000}`)
+console.log(`GitHub App callback URL: ${baseUrl}/dashboard/callback — configure this in GitHub App settings if you changed domains`)
+
 // Export for Vercel serverless
 export default app
 


### PR DESCRIPTION
Logs the expected GitHub App callback URL at startup so developers know what to configure in GitHub App settings after domain changes.

Closes #104