### PR TITLE
builder-tui: toasts, poll spinner, worktree hydration, Command mode

### DIFF
--- a/tools/builder-tui/src/app.rs
+++ b/tools/builder-tui/src/app.rs
@@ -1,4 +1,7 @@
+use std::collections::HashMap;
 use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::time::{Duration, Instant};
 
 use crossterm::event::{KeyCode, KeyModifiers, MouseEvent, MouseEventKind};
@@ -13,6 +16,22 @@ pub enum Mode {
     Normal,
     Send,      // typing a prompt for the selected worker
     Broadcast, // typing a prompt for all idle workers
+    Command,   // free-form builder command (`:` key)
+}
+
+#[derive(Clone, Debug)]
+pub enum ToastLevel {
+    Info,
+    Success,
+    Warning,
+    Error,
+}
+
+#[derive(Clone, Debug)]
+pub struct Toast {
+    pub message: String,
+    pub level: ToastLevel,
+    pub expires_at: Instant,
 }
 
 pub struct App {
@@ -26,8 +45,13 @@ pub struct App {
     pub logs: VecDeque<String>,
     pub show_logs: bool,
     pub next_scan_at: Option<Instant>,
+    pub toasts: Vec<Toast>,
+    pub frame: u64,
+    pub is_polling: Arc<AtomicBool>,
+    prev_worker_states: HashMap<String, String>,
     rx: watch::Receiver<Vec<WorkerState>>,
     log_rx: Option<mpsc::UnboundedReceiver<String>>,
+    cmd_tx: Option<mpsc::UnboundedSender<String>>,
 }
 
 impl App {
@@ -35,6 +59,8 @@ impl App {
         session: String,
         rx: watch::Receiver<Vec<WorkerState>>,
         log_rx: Option<mpsc::UnboundedReceiver<String>>,
+        is_polling: Arc<AtomicBool>,
+        cmd_tx: Option<mpsc::UnboundedSender<String>>,
     ) -> Self {
         Self {
             session,
@@ -47,15 +73,76 @@ impl App {
             logs: VecDeque::with_capacity(LOG_CAP),
             show_logs: false,
             next_scan_at: None,
+            toasts: Vec::new(),
+            frame: 0,
+            is_polling,
+            prev_worker_states: HashMap::new(),
             rx,
             log_rx,
+            cmd_tx,
+        }
+    }
+
+    pub fn push_toast(&mut self, msg: &str, level: ToastLevel) {
+        let duration = match level {
+            ToastLevel::Info | ToastLevel::Success => Duration::from_secs(4),
+            ToastLevel::Warning => Duration::from_secs(6),
+            ToastLevel::Error => Duration::from_secs(8),
+        };
+        self.toasts.push(Toast {
+            message: msg.to_string(),
+            level,
+            expires_at: Instant::now() + duration,
+        });
+        // Keep at most 10 toasts queued
+        if self.toasts.len() > 10 {
+            self.toasts.remove(0);
         }
     }
 
     pub fn tick(&mut self) {
+        self.frame = self.frame.wrapping_add(1);
+
+        // Expire old toasts
+        let now = Instant::now();
+        self.toasts.retain(|t| t.expires_at > now);
+
         // Pick up latest worker state from poller
         if self.rx.has_changed().unwrap_or(false) {
             let new_workers = self.rx.borrow_and_update().clone();
+
+            // Detect state transitions and emit auto-toasts
+            for w in &new_workers {
+                if let Some(prev_status) = self.prev_worker_states.get(&w.window_name) {
+                    if prev_status != &w.status {
+                        let toast = match (prev_status.as_str(), w.status.as_str()) {
+                            (prev, "active") if prev != "active" => {
+                                Some((format!("{} started working", w.window_name), ToastLevel::Info))
+                            }
+                            ("active", "done") => {
+                                Some((format!("{} has a PR!", w.window_name), ToastLevel::Success))
+                            }
+                            ("shell", "idle") => {
+                                Some((format!("{} Claude relaunched", w.window_name), ToastLevel::Info))
+                            }
+                            (_, "no-window") => {
+                                Some((format!("{} window lost", w.window_name), ToastLevel::Warning))
+                            }
+                            _ => None,
+                        };
+                        if let Some((msg, level)) = toast {
+                            self.push_toast(&msg, level);
+                        }
+                    }
+                }
+            }
+
+            // Update prev states
+            self.prev_worker_states.clear();
+            for w in &new_workers {
+                self.prev_worker_states.insert(w.window_name.clone(), w.status.clone());
+            }
+
             self.workers = new_workers;
             self.last_refresh = Instant::now();
 
@@ -64,21 +151,52 @@ impl App {
             }
         }
 
-        // Drain builder log channel
-        if let Some(rx) = &mut self.log_rx {
+        // Drain builder log channel — collect first to avoid borrow issues
+        let messages: Vec<String> = if let Some(rx) = &mut self.log_rx {
+            let mut buf = Vec::new();
             while let Ok(msg) = rx.try_recv() {
-                if let Some(rest) = msg.strip_prefix("__NEXT_SCAN_") {
-                    if let Some(secs_str) = rest.strip_suffix("__") {
-                        if let Ok(secs) = secs_str.parse::<u64>() {
-                            self.next_scan_at = Some(Instant::now() + Duration::from_secs(secs));
-                        }
+                buf.push(msg);
+            }
+            buf
+        } else {
+            Vec::new()
+        };
+
+        for msg in messages {
+            if let Some(rest) = msg.strip_prefix("__NEXT_SCAN_") {
+                if let Some(secs_str) = rest.strip_suffix("__") {
+                    if let Ok(secs) = secs_str.parse::<u64>() {
+                        self.next_scan_at = Some(Instant::now() + Duration::from_secs(secs));
                     }
-                } else {
-                    if self.logs.len() >= LOG_CAP {
-                        self.logs.pop_front();
-                    }
-                    self.logs.push_back(msg);
                 }
+            } else if let Some(rest) = msg.strip_prefix("__TOAST_") {
+                // Format: __TOAST_<LEVEL>_<message>__
+                if let Some(body) = rest.strip_suffix("__") {
+                    let parsed = if let Some(m) = body.strip_prefix("INFO_") {
+                        Some((ToastLevel::Info, m.to_string()))
+                    } else if let Some(m) = body.strip_prefix("SUCCESS_") {
+                        Some((ToastLevel::Success, m.to_string()))
+                    } else if let Some(m) = body.strip_prefix("WARNING_") {
+                        Some((ToastLevel::Warning, m.to_string()))
+                    } else if let Some(m) = body.strip_prefix("ERROR_") {
+                        Some((ToastLevel::Error, m.to_string()))
+                    } else {
+                        None
+                    };
+                    if let Some((level, message)) = parsed {
+                        self.push_toast(&message, level);
+                    } else {
+                        if self.logs.len() >= LOG_CAP {
+                            self.logs.pop_front();
+                        }
+                        self.logs.push_back(msg);
+                    }
+                }
+            } else {
+                if self.logs.len() >= LOG_CAP {
+                    self.logs.pop_front();
+                }
+                self.logs.push_back(msg);
             }
         }
     }
@@ -87,7 +205,7 @@ impl App {
     pub fn handle_key(&mut self, code: KeyCode, modifiers: KeyModifiers) -> bool {
         match &self.mode {
             Mode::Normal => self.handle_normal_key(code, modifiers),
-            Mode::Send | Mode::Broadcast => self.handle_input_key(code),
+            Mode::Send | Mode::Broadcast | Mode::Command => self.handle_input_key(code),
         }
     }
 
@@ -117,6 +235,11 @@ impl App {
             KeyCode::Char('l') => {
                 self.show_logs = !self.show_logs;
             }
+            KeyCode::Char(':') => {
+                self.mode = Mode::Command;
+                self.input.clear();
+                self.status_msg = "Builder command (Enter to send, Esc to cancel)".into();
+            }
             _ => {}
         }
         false
@@ -134,6 +257,7 @@ impl App {
                 match &self.mode {
                     Mode::Send => self.send_to_selected(&text),
                     Mode::Broadcast => self.broadcast(&text),
+                    Mode::Command => self.execute_command(&text),
                     Mode::Normal => {}
                 }
                 self.mode = Mode::Normal;
@@ -229,6 +353,20 @@ impl App {
             self.status_msg = format!("Broadcast to {count} idle workers");
         } else {
             self.status_msg = format!("Broadcast done ({errors} errors)");
+        }
+    }
+
+    fn execute_command(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        let preview: String = text.chars().take(40).collect();
+        if let Some(tx) = &self.cmd_tx {
+            let _ = tx.send(text.to_string());
+            self.status_msg = format!("Command sent: {preview}");
+            self.push_toast(&format!("Command: {preview}"), ToastLevel::Info);
+        } else {
+            self.status_msg = "Builder not running (--no-builder)".into();
         }
     }
 

--- a/tools/builder-tui/src/builder.rs
+++ b/tools/builder-tui/src/builder.rs
@@ -6,6 +6,10 @@ use crate::config::Config;
 use crate::github;
 use crate::monitor::BackoffState;
 
+fn toast(tx: &mpsc::UnboundedSender<String>, level: &str, msg: &str) {
+    let _ = tx.send(format!("__TOAST_{level}_{msg}__"));
+}
+
 #[derive(serde::Deserialize)]
 struct Task {
     title: String,
@@ -101,6 +105,8 @@ async fn process_task(
     };
 
     log(log_tx, format!("[builder] Created issue #{issue_num}"));
+    let title_preview: String = task.title.chars().take(30).collect();
+    toast(log_tx, "SUCCESS", &format!("Filed #{issue_num}: {title_preview}"));
 
     let comment = format!(
         "🔨 **Vyshnav (Builder):** Picked this up → created #{}: **{}**. Spinning up a worktree now.\n\n**— Vyshnav (simulated builder)**",
@@ -161,14 +167,59 @@ async fn process_task(
     log(log_tx, format!("[builder] Launched Claude in {}:{window} for issue #{issue_num}", config.session));
 }
 
+async fn handle_command(config: &Arc<Config>, cmd: &str, log_tx: &mpsc::UnboundedSender<String>) {
+    let lower = cmd.to_lowercase();
+
+    if lower.contains("rebase all") {
+        log(log_tx, "[builder] Command: triggering rebase");
+        crate::monitor::notify_rebase(config, log_tx).await;
+    } else if lower.starts_with("nudge all") || lower.starts_with("broadcast ") {
+        let msg = if lower.starts_with("broadcast ") {
+            &cmd["broadcast ".len()..]
+        } else {
+            "continue with the task"
+        };
+        log(log_tx, format!("[builder] Command: broadcasting to idle workers: {msg}"));
+        let windows = crate::monitor::list_windows(config).await;
+        for (idx, _) in &windows {
+            let pane = {
+                let target = format!("{}:{}", config.session, idx);
+                tokio::process::Command::new(&config.tmux)
+                    .args(["capture-pane", "-t", &target, "-p"])
+                    .output()
+                    .await
+                    .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
+                    .unwrap_or_default()
+            };
+            if pane.contains("bypass permissions on") {
+                let target = format!("{}:{}", config.session, idx);
+                let _ = tokio::process::Command::new(&config.tmux)
+                    .args(["send-keys", "-t", &target, msg, "Enter"])
+                    .output()
+                    .await;
+            }
+        }
+    } else {
+        // Pass through as-is to a log message — future: could invoke claude with command
+        log(log_tx, format!("[builder] Unrecognized command (logged only): {cmd}"));
+    }
+}
+
 pub async fn run(
     config: Arc<Config>,
     log_tx: mpsc::UnboundedSender<String>,
     backoff: Arc<Mutex<BackoffState>>,
+    mut cmd_rx: mpsc::UnboundedReceiver<String>,
 ) {
     log(&log_tx, "[builder] Starting builder loop...");
 
     loop {
+        // Drain any pending commands first (higher priority than scheduled scan)
+        while let Ok(cmd) = cmd_rx.try_recv() {
+            log(&log_tx, format!("[builder] Command received: {cmd}"));
+            handle_command(&config, &cmd, &log_tx).await;
+        }
+
         // Check backoff
         {
             let state = backoff.lock().await;
@@ -221,6 +272,7 @@ pub async fn run(
                 if is_rate_limited(&err_str) {
                     let wait = parse_retry_after(&err_str);
                     log(&log_tx, format!("[builder] Rate limited, backing off {wait}s"));
+                    toast(&log_tx, "WARNING", &format!("Rate limited — {wait}s"));
                     backoff.lock().await.set(wait);
                     sleep(Duration::from_secs(30)).await;
                     continue;

--- a/tools/builder-tui/src/main.rs
+++ b/tools/builder-tui/src/main.rs
@@ -7,6 +7,7 @@ mod poller;
 mod ui;
 
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 
 use app::App;
@@ -79,25 +80,38 @@ async fn main() -> anyhow::Result<()> {
 
     let config = Arc::new(config);
 
-    // Channel: poller -> main thread
-    let (tx, rx) = watch::channel(Vec::new());
+    // Shared polling indicator (set by poller, read by UI)
+    let is_polling = Arc::new(AtomicBool::new(false));
+
+    // Merged log channel: both poller and builder write here, App reads
+    let (log_tx, log_rx) = mpsc::unbounded_channel::<String>();
+
+    // Channel: poller -> App (worker states)
+    let (worker_tx, worker_rx) = watch::channel(Vec::new());
 
     // Spawn background poller
-    let session_clone = config.session.clone();
-    let interval = config.interval_secs;
-    tokio::spawn(async move {
-        poller::run(session_clone, interval, tx).await;
-    });
+    {
+        let session = config.session.clone();
+        let interval = config.interval_secs;
+        let repo_root = config.repo_root.clone();
+        let is_polling = Arc::clone(&is_polling);
+        let log_tx = log_tx.clone();
+        tokio::spawn(async move {
+            poller::run(session, interval, worker_tx, log_tx, repo_root, is_polling).await;
+        });
+    }
+
+    // Command channel: App -> builder
+    let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<String>();
 
     // Optional builder task
-    let log_rx = if config.run_builder {
-        let (log_tx, log_rx) = mpsc::unbounded_channel::<String>();
-        let backoff = Arc::new(Mutex::new(BackoffState::new()));
+    let cmd_tx_for_app = if config.run_builder {
         let config_clone = Arc::clone(&config);
+        let backoff = Arc::new(Mutex::new(BackoffState::new()));
         tokio::spawn(async move {
-            builder::run(config_clone, log_tx, backoff).await;
+            builder::run(config_clone, log_tx, backoff, cmd_rx).await;
         });
-        Some(log_rx)
+        Some(cmd_tx)
     } else {
         None
     };
@@ -109,7 +123,13 @@ async fn main() -> anyhow::Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let mut app = App::new(config.session.clone(), rx, log_rx);
+    let mut app = App::new(
+        config.session.clone(),
+        worker_rx,
+        Some(log_rx),
+        is_polling,
+        cmd_tx_for_app,
+    );
 
     loop {
         terminal.draw(|f| ui::draw(f, &app))?;

--- a/tools/builder-tui/src/monitor.rs
+++ b/tools/builder-tui/src/monitor.rs
@@ -54,6 +54,10 @@ fn log(tx: &mpsc::UnboundedSender<String>, msg: impl Into<String>) {
     let _ = tx.send(msg.into());
 }
 
+fn toast(tx: &mpsc::UnboundedSender<String>, level: &str, msg: &str) {
+    let _ = tx.send(format!("__TOAST_{level}_{msg}__"));
+}
+
 async fn capture_pane(config: &Config, idx: usize) -> String {
     let target = format!("{}:{}", config.session, idx);
     let Ok(out) = tokio::process::Command::new(&config.tmux)
@@ -229,6 +233,7 @@ pub async fn monitor_windows(
                 log_tx,
                 format!("[monitor] Issue #{issue_num}: Claude idle, no PR — nudging"),
             );
+            toast(log_tx, "INFO", &format!("Nudged #{issue_num}"));
             let msg = format!(
                 "Have you pushed the branch and opened a PR to main referencing #{}? If not, please do that now.",
                 issue_num
@@ -275,6 +280,7 @@ pub async fn monitor_windows(
                 log_tx,
                 format!("[monitor] Issue #{issue_num}: Claude exited without PR — relaunched"),
             );
+            toast(log_tx, "WARNING", &format!("Relaunched #{issue_num}"));
 
             let comment = format!(
                 "🔄 **Vyshnav (Builder):** Relaunched Claude on issue #{issue_num} — previous run exited without a PR.\n\n**— Vyshnav (simulated builder)**"
@@ -303,6 +309,7 @@ pub async fn cleanup_finished(config: &Config, log_tx: &mpsc::UnboundedSender<St
             log_tx,
             format!("[cleanup] Issue #{issue_num} closed — removing window {idx} and worktree"),
         );
+        toast(log_tx, "SUCCESS", &format!("Closed #{issue_num} — cleaned up"));
 
         let worktree = format!(
             "{}/.claude/worktrees/issue-{issue_num}",
@@ -343,7 +350,9 @@ pub async fn notify_rebase(config: &Config, log_tx: &mpsc::UnboundedSender<Strin
         return;
     }
 
-    log(log_tx, format!("[rebase] Detected {} merged PR(s) since {last_check}", merged.len()));
+    let merged_count = merged.len();
+    log(log_tx, format!("[rebase] Detected {merged_count} merged PR(s) since {last_check}"));
+    toast(log_tx, "INFO", &format!("{merged_count} PR(s) merged — rebasing"));
 
     // Pull latest main
     let _ = tokio::process::Command::new("git")
@@ -403,6 +412,7 @@ pub async fn resume_after_backoff(
     backoff.lock().await.clear();
 
     log(log_tx, "[builder] Backoff cleared — sending 'continue' to idle Claude windows");
+    toast(log_tx, "INFO", "Rate limit cleared");
 
     let windows = list_windows(config).await;
     for (idx, name) in &windows {

--- a/tools/builder-tui/src/poller.rs
+++ b/tools/builder-tui/src/poller.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
-use tokio::sync::watch;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use tokio::sync::{mpsc, watch};
 
 #[derive(Debug, Clone, serde::Deserialize, Default)]
 pub struct BuilderStatus {
@@ -11,24 +13,133 @@ pub struct BuilderStatus {
 pub struct WorkerState {
     pub window_index: usize,
     pub window_name: String,
-    pub status: String,  // "active" | "idle" | "shell" | "done" | "unknown"
+    pub status: String,  // "active" | "idle" | "shell" | "done" | "unknown" | "no-window"
     pub pr: Option<String>,
     pub last_output: String,
 }
 
-pub async fn run(session: String, interval_secs: u64, tx: watch::Sender<Vec<WorkerState>>) {
+pub async fn run(
+    session: String,
+    interval_secs: u64,
+    tx: watch::Sender<Vec<WorkerState>>,
+    log_tx: mpsc::UnboundedSender<String>,
+    repo_root: String,
+    is_polling: Arc<AtomicBool>,
+) {
+    let mut prev_states: HashMap<String, String> = HashMap::new();
+    // Slow scan every max(interval_secs, 60) seconds; counter ticks every 1s
+    let slow_every = interval_secs.max(60);
+    let mut slow_counter: u64 = 0;
+    let mut first_run = true;
+
     loop {
-        let states = poll_session(&session);
+        is_polling.store(true, Ordering::Relaxed);
+
+        let do_slow = slow_counter == 0;
+        slow_counter = (slow_counter + 1) % slow_every;
+
+        let builder_status = load_builder_status();
+
+        // Fast path: get tmux windows
+        let mut states = poll_tmux_windows(&session, &builder_status);
+
+        // Slow path: merge orphaned worktrees
+        if (do_slow || first_run) && !repo_root.is_empty() {
+            let worktree_issues = scan_worktrees(&repo_root);
+            let tmux_names: Vec<String> = states.iter().map(|w| w.window_name.clone()).collect();
+
+            let mut orphan_count = 0;
+            for issue_num in worktree_issues {
+                let name = format!("issue-{issue_num}");
+                if !tmux_names.contains(&name) {
+                    let pr = builder_status.prs.get(&name).cloned();
+                    states.push(WorkerState {
+                        window_index: usize::MAX,
+                        window_name: name,
+                        status: "no-window".to_string(),
+                        pr,
+                        last_output: "(orphaned worktree)".to_string(),
+                    });
+                    orphan_count += 1;
+                }
+            }
+
+            if first_run {
+                let total = states.len();
+                let msg = if orphan_count > 0 {
+                    format!("__TOAST_INFO_Loaded {total} workers ({orphan_count} orphaned)__")
+                } else {
+                    format!("__TOAST_INFO_Loaded {total} workers__")
+                };
+                let _ = log_tx.send(msg);
+                first_run = false;
+            }
+        }
+
+        // Detect state transitions
+        for w in &states {
+            if let Some(prev) = prev_states.get(&w.window_name) {
+                if prev != &w.status {
+                    let toast = match (prev.as_str(), w.status.as_str()) {
+                        (p, "active") if p != "active" => {
+                            Some(format!("__TOAST_INFO_{} started working__", w.window_name))
+                        }
+                        ("active", "done") => {
+                            Some(format!("__TOAST_SUCCESS_{} has a PR!__", w.window_name))
+                        }
+                        ("shell", "idle") => {
+                            Some(format!("__TOAST_INFO_{} Claude relaunched__", w.window_name))
+                        }
+                        (_, "no-window") => {
+                            Some(format!("__TOAST_WARNING_{} window lost__", w.window_name))
+                        }
+                        _ => None,
+                    };
+                    if let Some(msg) = toast {
+                        let _ = log_tx.send(msg);
+                    }
+                }
+            }
+        }
+
+        // Update prev states
+        prev_states.clear();
+        for w in &states {
+            prev_states.insert(w.window_name.clone(), w.status.clone());
+        }
+
         let _ = tx.send(states);
-        tokio::time::sleep(tokio::time::Duration::from_secs(interval_secs)).await;
+        is_polling.store(false, Ordering::Relaxed);
+
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
     }
 }
 
-fn poll_session(session: &str) -> Vec<WorkerState> {
-    // Load builder-status.json if present
-    let builder_status = load_builder_status();
+/// Scan `.claude/worktrees/` for `issue-N` directories and return sorted issue numbers.
+pub fn scan_worktrees(repo_root: &str) -> Vec<u64> {
+    let worktrees_dir = format!("{repo_root}/.claude/worktrees");
+    let Ok(entries) = std::fs::read_dir(&worktrees_dir) else {
+        return Vec::new();
+    };
 
-    // List windows
+    let mut issues: Vec<u64> = entries
+        .flatten()
+        .filter_map(|e| {
+            let name = e.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.starts_with("issue-") {
+                name_str["issue-".len()..].parse::<u64>().ok()
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    issues.sort_unstable();
+    issues
+}
+
+fn poll_tmux_windows(session: &str, builder_status: &BuilderStatus) -> Vec<WorkerState> {
     let Ok(out) = std::process::Command::new("/opt/homebrew/bin/tmux")
         .args(["list-windows", "-t", session, "-F", "#{window_index} #{window_name}"])
         .output()
@@ -47,9 +158,7 @@ fn poll_session(session: &str) -> Vec<WorkerState> {
 
         let pane_content = capture_pane(session, idx);
         let last_output = last_nonempty_line(&pane_content);
-
         let pr = builder_status.prs.get(name).cloned();
-
         let status = classify_state(&pane_content, pr.is_some());
 
         states.push(WorkerState {
@@ -112,7 +221,6 @@ fn classify_state(pane: &str, has_pr: bool) -> String {
     } else if is_shell && has_pr {
         "done".to_string()
     } else if is_shell {
-        // Distinguish queued (never launched Claude) from shell (crashed after running)
         let has_claude_trace = pane.contains("claude") || pane.contains("Implement");
         if has_claude_trace {
             "shell".to_string()

--- a/tools/builder-tui/src/ui.rs
+++ b/tools/builder-tui/src/ui.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::Ordering;
+
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
@@ -6,7 +8,9 @@ use ratatui::{
     widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState},
 };
 
-use crate::app::{App, Mode};
+use crate::app::{App, Mode, ToastLevel};
+
+const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 pub fn draw(f: &mut Frame, app: &App) {
     let area = f.area();
@@ -34,18 +38,34 @@ pub fn draw(f: &mut Frame, app: &App) {
     }
 
     draw_footer(f, app, chunks[2]);
+
+    // Toast overlay — rendered last so it appears on top
+    draw_toasts(f, app, area);
 }
 
 fn draw_header(f: &mut Frame, app: &App, area: Rect) {
     let backoff = app.backoff_status();
-    let refresh_ago = {
+
+    let polling = app.is_polling.load(Ordering::Relaxed);
+    let scan_span = if polling {
+        let spinner = SPINNER[(app.frame as usize) % SPINNER.len()];
+        Span::styled(
+            format!("{spinner} Polling..."),
+            Style::default().fg(Color::Cyan),
+        )
+    } else {
         let secs = app.last_refresh_secs();
-        if secs < 60 {
+        let ago = if secs < 60 {
             format!("{secs}s ago")
         } else {
             format!("{}m ago", secs / 60)
-        }
+        };
+        Span::styled(
+            format!("✓ Last scan: {ago}"),
+            Style::default().fg(Color::Green),
+        )
     };
+
     let next_scan = match app.next_scan_remaining_secs() {
         Some(s) if s > 0 => format!("{s}s"),
         Some(_) => "now".to_string(),
@@ -82,7 +102,7 @@ fn draw_header(f: &mut Frame, app: &App, area: Rect) {
         Line::from(vec![
             Span::raw(format!(" Backoff: {backoff}")),
             Span::raw("   "),
-            Span::raw(format!("Last scan: {refresh_ago}")),
+            scan_span,
             Span::raw("   "),
             Span::styled(
                 format!("Next scan: {next_scan}"),
@@ -199,7 +219,7 @@ fn draw_logs(f: &mut Frame, app: &App, area: Rect) {
 fn draw_footer(f: &mut Frame, app: &App, area: Rect) {
     let (title, content) = match &app.mode {
         Mode::Normal => {
-            let hint = " [s] Send  [i] Interrupt  [b] Broadcast  [r] Refresh  [l] Log  [q] Quit";
+            let hint = " [s] Send  [i] Interrupt  [b] Broadcast  [r] Refresh  [l] Log  [:] Command  [q] Quit";
             let msg = if app.status_msg.is_empty() {
                 hint.to_string()
             } else {
@@ -222,6 +242,10 @@ fn draw_footer(f: &mut Frame, app: &App, area: Rect) {
             "Broadcast to idle workers".to_string(),
             format!(" > {}_", app.input),
         ),
+        Mode::Command => (
+            "Builder Command".to_string(),
+            format!(" : {}_", app.input),
+        ),
     };
 
     let block = Block::default()
@@ -233,6 +257,64 @@ fn draw_footer(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(para, area);
 }
 
+fn draw_toasts(f: &mut Frame, app: &App, area: Rect) {
+    if app.toasts.is_empty() {
+        return;
+    }
+
+    const TOAST_WIDTH: u16 = 42;
+    const TOAST_HEIGHT: u16 = 3;
+    const MAX_VISIBLE: usize = 4;
+
+    // Show newest toasts on top (take last MAX_VISIBLE, reversed)
+    let visible: Vec<_> = app
+        .toasts
+        .iter()
+        .rev()
+        .take(MAX_VISIBLE)
+        .collect();
+
+    let total_height = visible.len() as u16 * TOAST_HEIGHT;
+    if area.width < TOAST_WIDTH + 2 || area.height < total_height + 2 {
+        return;
+    }
+
+    let start_x = area.right().saturating_sub(TOAST_WIDTH + 1);
+    let start_y = area.y + 1; // Below top border
+
+    for (i, toast) in visible.iter().enumerate() {
+        let y = start_y + i as u16 * TOAST_HEIGHT;
+        if y + TOAST_HEIGHT > area.bottom() {
+            break;
+        }
+
+        let toast_rect = Rect {
+            x: start_x,
+            y,
+            width: TOAST_WIDTH,
+            height: TOAST_HEIGHT,
+        };
+
+        let (icon, border_color, title) = match toast.level {
+            ToastLevel::Success => ("✅", Color::Green, "Done"),
+            ToastLevel::Info => ("ℹ", Color::Cyan, "Info"),
+            ToastLevel::Warning => ("⚠", Color::Yellow, "Warning"),
+            ToastLevel::Error => ("✗", Color::Red, "Error"),
+        };
+
+        let max_msg_width = (TOAST_WIDTH as usize).saturating_sub(4);
+        let msg: String = toast.message.chars().take(max_msg_width).collect();
+
+        let block = Block::default()
+            .title(format!(" {icon} {title} "))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(border_color));
+
+        let para = Paragraph::new(msg).block(block);
+        f.render_widget(para, toast_rect);
+    }
+}
+
 fn status_icon(status: &str) -> String {
     match status {
         "active" => "🟢 active".to_string(),
@@ -242,6 +324,7 @@ fn status_icon(status: &str) -> String {
         "queued" => "⏳ queued".to_string(),
         "sleeping" => "💤 sleeping".to_string(),
         "posted" => "✅ posted".to_string(),
+        "no-window" => "👻 no-window".to_string(),
         _ => "❓ unknown".to_string(),
     }
 }
@@ -255,6 +338,7 @@ fn status_style(status: &str) -> Style {
         "queued" => Style::default().fg(Color::DarkGray),
         "sleeping" => Style::default().fg(Color::Blue),
         "posted" => Style::default().fg(Color::Cyan),
+        "no-window" => Style::default().fg(Color::Magenta),
         _ => Style::default(),
     }
 }


### PR DESCRIPTION
## What

Fault tolerance and UX improvements for the Rust TUI builder.

**Toast overlay** — floating top-right corner boxes (Info/Success/Warning/Error) with auto-expiry (4-8s). Emitted by poller on state transitions and by builder/monitor on key events.

**Animated poll spinner** — header shows `⠋ Polling...` (braille spinner cycling on frame counter) while scanning, `✓ Last scan: Xs ago` when idle.

**Startup state hydration** — on first tick, scans `.claude/worktrees/issue-*` and synthesizes `👻 no-window` rows for any worktrees without a live tmux window. TUI is no longer blank on restart.

**Fast/slow polling** — 1s loop for tmux classification (responsive state changes), slow loop for worktree scan. Worker state changes visible within 1s.

**Command mode** — press `:` to open a free-form builder command bar. Supports `rebase all`, `nudge all`, `broadcast <msg>`; unrecognized commands are logged. Dispatched via `cmd_tx` into the builder loop.

## Changed files

- `app.rs` — `Toast`/`ToastLevel` types, `frame` counter, `is_polling` flag, `prev_worker_states` diff, `Mode::Command`, `cmd_tx`
- `ui.rs` — `draw_toasts()` overlay, spinner in header, `no-window` status, Command mode footer
- `poller.rs` — `scan_worktrees()`, fast 1s loop, state-transition detection → `__TOAST__` messages
- `builder.rs` — `cmd_rx` handling, toast emissions for filed issues and rate limits
- `monitor.rs` — toast emissions for nudge, relaunch, cleanup, rebase
- `main.rs` — merged log channel, `Arc<AtomicBool>` for polling indicator, `cmd_tx/cmd_rx` wiring