### PR TITLE
Add GITHUB_APP_SLUG to startup env var validation

### DIFF
--- a/apps/server/src/validateEnv.ts
+++ b/apps/server/src/validateEnv.ts
@@ -11,6 +11,7 @@ interface EnvVar {
 // Always required
 const REQUIRED: EnvVar[] = [
   { name: 'GITHUB_APP_ID', description: 'GitHub App ID (found in GitHub App settings)' },
+  { name: 'GITHUB_APP_SLUG', description: 'GitHub App slug (used in install URLs, e.g. "my-app")' },
   { name: 'GITHUB_APP_CLIENT_ID', description: 'GitHub App OAuth client ID' },
   { name: 'GITHUB_APP_CLIENT_SECRET', description: 'GitHub App OAuth client secret' },
   { name: 'POSTGRES_URL', description: 'Neon Postgres connection string' },


### PR DESCRIPTION
Closes #109

Adds `GITHUB_APP_SLUG` to the required vars in `validateEnv.ts` so deployments missing this var fail loudly at startup rather than silently at runtime.