### PR TITLE
Show time_to_comment in invite funnel dashboard

### DIFF
--- a/apps/server/src/connect.ts
+++ b/apps/server/src/connect.ts
@@ -250,9 +250,10 @@ export async function handleDashboard(req: Request, res: Response): Promise<void
         <td class="p-3 border-r-2 border-black text-center">${check(f.invite_opened)}</td>
         <td class="p-3 border-r-2 border-black text-center">${check(f.config_started)}</td>
         <td class="p-3 border-r-2 border-black text-center">${check(f.issue_viewed)}</td>
-        <td class="p-3 text-center">${check(f.comment_submitted)}</td>
+        <td class="p-3 border-r-2 border-black text-center">${check(f.comment_submitted)}</td>
+        <td class="p-3 text-center text-xs ${f.time_to_comment ? 'font-bold' : 'text-gray-300'}">${f.time_to_comment ?? '—'}</td>
       </tr>`).join('')
-    : `<tr><td colspan="7" class="p-4 text-sm text-gray-400 text-center">No invites yet — create one below</td></tr>`
+    : `<tr><td colspan="8" class="p-4 text-sm text-gray-400 text-center">No invites yet — create one below</td></tr>`
 
   const designerRows = sessions.length
     ? sessions.map(s => `
@@ -365,7 +366,8 @@ export async function handleDashboard(req: Request, res: Response): Promise<void
             <th class="text-center p-3 border-r-2 border-white">Opened</th>
             <th class="text-center p-3 border-r-2 border-white">Config</th>
             <th class="text-center p-3 border-r-2 border-white">Issue Viewed</th>
-            <th class="text-center p-3">Comment</th>
+            <th class="text-center p-3 border-r-2 border-white">Comment</th>
+            <th class="text-center p-3">Time to Comment</th>
           </tr>
         </thead>
         <tbody>${funnelRows}</tbody>

--- a/apps/server/src/db.ts
+++ b/apps/server/src/db.ts
@@ -119,6 +119,16 @@ export interface FunnelRow {
   config_started: boolean
   issue_viewed: boolean
   comment_submitted: boolean
+  time_to_comment: string | null
+}
+
+function formatDuration(secs: number): string {
+  if (secs < 60) return `${secs}s`
+  const mins = Math.floor(secs / 60)
+  if (mins < 60) return `${mins}m`
+  const hrs = Math.floor(mins / 60)
+  const remainMins = mins % 60
+  return remainMins > 0 ? `${hrs}h ${remainMins}m` : `${hrs}h`
 }
 
 export interface InviteCode {
@@ -289,14 +299,23 @@ export async function getFunnelForUser(userId: string): Promise<FunnelRow[]> {
       bool_or(ie.event_type = 'invite_opened')     AS invite_opened,
       bool_or(ie.event_type = 'config_started')    AS config_started,
       bool_or(ie.event_type = 'issue_viewed')      AS issue_viewed,
-      bool_or(ie.event_type = 'comment_submitted') AS comment_submitted
+      bool_or(ie.event_type = 'comment_submitted') AS comment_submitted,
+      EXTRACT(EPOCH FROM (
+        MIN(CASE WHEN ie.event_type = 'comment_submitted' THEN ie.created_at END) -
+        MIN(CASE WHEN ie.event_type = 'invite_generated'  THEN ie.created_at END)
+      ))::int AS time_to_comment_secs
     FROM invite_codes ic
     LEFT JOIN invite_events ie ON ie.invite_code = ic.code
     WHERE ic.user_id = ${userId}
     GROUP BY ic.code, ic.created_at
     ORDER BY ic.created_at DESC
   `
-  return rows as FunnelRow[]
+  return (rows as Array<Record<string, unknown>>).map(r => ({
+    ...r,
+    time_to_comment: r['time_to_comment_secs'] != null
+      ? formatDuration(r['time_to_comment_secs'] as number)
+      : null,
+  })) as FunnelRow[]
 }
 
 export async function countInviteCodes(): Promise<number> {


### PR DESCRIPTION
Adds elapsed time from invite generation to first comment submission in the invite funnel dashboard.

- Extends `FunnelRow` interface with `time_to_comment` field
- SQL query computes interval between `invite_generated` and `comment_submitted` events
- Funnel table displays formatted duration (e.g. '2h 14m') or '—' if no comment yet

Closes #138