### PR TITLE
Add designer name to comment attribution

### DIFF
--- a/apps/server/src/designer.ts
+++ b/apps/server/src/designer.ts
@@ -393,13 +393,16 @@ export async function handleDesignerComment(req: Request, res: Response): Promis
     }
   }
 
+  const designerName = ctx.session.github_user
+  const prefix = designerName ? `[Designer: ${designerName}] ` : '[Designer] '
+
   try {
     await addComment({
       owner: ctx.owner,
       repo: ctx.repo,
       issueNumber,
       token: ctx.token,
-      body: `[Designer] ${commentBody}${imageMarkdown}`,
+      body: `${prefix}${commentBody}${imageMarkdown}`,
     })
   } catch (err) {
     res.status(502).send(`GitHub error: ${err instanceof Error ? err.message : String(err)}`)

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -69,6 +69,7 @@ interface AuthContext {
   repo: { owner: string; repo: string }
   userId: string
   inviteCode: string | null
+  designerName: string | null
 }
 
 function loadPrivateKey(): string {
@@ -111,7 +112,7 @@ async function resolveAuth(req: Request): Promise<AuthContext | null> {
     if (!user.repo) return null
     const [owner, repo] = user.repo.split('/')
     if (!owner || !repo) return null
-    return { role: 'developer', installationId: user.installation_id, repo: { owner, repo }, userId: user.id, inviteCode: null }
+    return { role: 'developer', installationId: user.installation_id, repo: { owner, repo }, userId: user.id, inviteCode: null, designerName: null }
   }
 
   // Try designer (session token)
@@ -130,7 +131,7 @@ async function resolveAuth(req: Request): Promise<AuthContext | null> {
 
     const [owner, repo] = repoFullName.split('/')
     if (!owner || !repo) return null
-    return { role: 'designer', installationId: ownerUser.installation_id, repo: { owner, repo }, userId: session.user_id, inviteCode: session.invite_code }
+    return { role: 'designer', installationId: ownerUser.installation_id, repo: { owner, repo }, userId: session.user_id, inviteCode: session.invite_code, designerName: session.github_user }
   }
 
   return null
@@ -298,7 +299,7 @@ async function callTool(
       if (ctx.role === 'designer' && ctx.inviteCode) {
         void db.recordInviteEvent(ctx.inviteCode, 'comment_submitted')
       }
-      const prefix = ctx.role === 'developer' ? '[Developer] ' : '[Designer] '
+      const prefix = ctx.role === 'developer' ? '[Developer] ' : ctx.designerName ? `[Designer: ${ctx.designerName}] ` : '[Designer] '
       const comment = await addComment({ owner, repo, issueNumber, token, body: `${prefix}${body}` })
       cacheInvalidateRepo(owner, repo)
       return { content: [{ type: 'text', text: `Comment added: ${comment.html_url}` }] }
@@ -311,7 +312,7 @@ async function callTool(
       if (ctx.role === 'designer' && ctx.inviteCode) {
         void db.recordInviteEvent(ctx.inviteCode, 'comment_submitted')
       }
-      const prefix = ctx.role === 'developer' ? '[Developer] ' : '[Designer] '
+      const prefix = ctx.role === 'developer' ? '[Developer] ' : ctx.designerName ? `[Designer: ${ctx.designerName}] ` : '[Designer] '
       let commentBody = `${prefix}## Decision\n${decision}`
       if (rationale) commentBody += `\n\n**Rationale:** ${rationale}`
       const comment = await addComment({ owner, repo, issueNumber, token, body: commentBody })


### PR DESCRIPTION
Stores the display name entered on the invite page and includes it in comments as `[Designer: <name>]` instead of plain `[Designer]`.

Closes #139